### PR TITLE
Fix node version at Dockerfile and work with AWS CodeBuild

### DIFF
--- a/00-Application/Dockerfile
+++ b/00-Application/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.4-alpine
+FROM node:10.17.0-alpine
 COPY app/ /app
 WORKDIR /app
 RUN npm install --global gulp && npm install gulp


### PR DESCRIPTION
Updating the node version at Dockerfile  fix error "gulp: command not found" when you try build with AWS CodeBuild.